### PR TITLE
also handle errors not caused by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next
+
+### Changed
+
+- Upgraded to iexec ^8.9.1
+- Upgraded to ES2023 in order to support cause option in Error.
+- Upgrade typescript version dependency to support es2023
+
+### Removed
+
+- Removed `OriginalError` from `WorkflowError`
+
 ## [2.1.0] 2024-03-15
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Upgraded to iexec ^8.9.1
-- Upgraded to ES2023 in order to support cause option in Error.
-- Upgrade typescript version dependency to support es2023
-
-### Removed
-
-- Removed `cause` from `WorkflowError`
+- [BREAKING] Ship ES2022 JavaScript instead of es2015 (aka es6) in order to support `cause` optional field in `Error`:
+  - Minimum browser versions: <https://gist.github.com/Julien-Marcou/156b19aea4704e1d2f48adafc6e2acbf>
+  - Minimum Node.js version: 18
+- Upgrade typescript version
+- Changed `fetchMyContacts`, `fetchUserContacts` and `sendEmail` error handling:
+  - Distinguish iExec protocol errors from other errors
+  - Store original error as the error cause
+- [BREAKING] Removed `originalError` from `WorkflowError`
 
 ## [2.1.0] 2024-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Upgraded to iexec ^8.9.1
-- [BREAKING] Ship ES2022 JavaScript instead of es2015 (aka es6) in order to support `cause` optional field in `Error`:
+- [BREAKING] Ship ES2022 JavaScript instead of es2015 (aka es6) in order to support `errorCause` optional field in `Error`:
   - Minimum browser versions: <https://gist.github.com/Julien-Marcou/156b19aea4704e1d2f48adafc6e2acbf>
   - Minimum Node.js version: 18
 - Upgrade typescript version
 - Changed `fetchMyContacts`, `fetchUserContacts` and `sendEmail` error handling:
   - Distinguish iExec protocol errors from other errors
-  - Store original error as the error cause
+  - Store original error as the error errorCause
 - [BREAKING] Removed `originalError` from `WorkflowError`
 
 ## [2.1.0] 2024-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- Removed `OriginalError` from `WorkflowError`
+- Removed `cause` from `WorkflowError`
 
 ## [2.1.0] 2024-03-15
 

--- a/LICENSE
+++ b/LICENSE
@@ -17,7 +17,7 @@ License: Apache2.0
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
+      "control" means (i) the power, direct or indirect, to errorCause the
       direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
@@ -96,7 +96,7 @@ License: Apache2.0
       (a) You must give any other recipients of the Work or
           Derivative Works a copy of this License; and
 
-      (b) You must cause any modified files to carry prominent notices
+      (b) You must errorCause any modified files to carry prominent notices
           stating that You changed the files; and
 
       (c) You must retain, in the Source form of any Derivative Works

--- a/LICENSE
+++ b/LICENSE
@@ -17,7 +17,7 @@ License: Apache2.0
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
       control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to errorCause the
+      "control" means (i) the power, direct or indirect, to cause the
       direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
@@ -96,7 +96,7 @@ License: Apache2.0
       (a) You must give any other recipients of the Work or
           Derivative Works a copy of this License; and
 
-      (b) You must errorCause any modified files to carry prominent notices
+      (b) You must cause any modified files to carry prominent notices
           stating that You changed the files; and
 
       (c) You must retain, in the Source form of any Derivative Works

--- a/browser-test/src/helpers.js
+++ b/browser-test/src/helpers.js
@@ -34,8 +34,8 @@ export const formatObservableData = (data) => {
 
 export const formatObservableError = (error) => {
   let message = `ERROR\n${error.toString()}`;
-  if (error.originalError) {
-    message += `\n${error.originalError.toString()}`;
+  if (error.cause) {
+    message += `\n${error.cause.toString()}`;
   }
   return message;
 };

--- a/browser-test/src/helpers.js
+++ b/browser-test/src/helpers.js
@@ -34,8 +34,8 @@ export const formatObservableData = (data) => {
 
 export const formatObservableError = (error) => {
   let message = `ERROR\n${error.toString()}`;
-  if (error.cause) {
-    message += `\n${error.cause.toString()}`;
+  if (error.errorCause) {
+    message += `\n${error.errorCause.toString()}`;
   }
   return message;
 };

--- a/docs/classes/errors.WorkflowError.md
+++ b/docs/classes/errors.WorkflowError.md
@@ -18,20 +18,20 @@
 
 ### Properties
 
-- [cause](errors.WorkflowError.md#cause)
+- [errorCause](errors.WorkflowError.md#errorCause)
 
 ## Constructors
 
 ### constructor
 
-• **new WorkflowError**(`message`, `cause?`): [`WorkflowError`](errors.WorkflowError.md)
+• **new WorkflowError**(`message`, `errorCause?`): [`WorkflowError`](errors.WorkflowError.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message` | `string` |
-| `cause?` | `Error` |
+| `errorCause?` | `Error` |
 
 #### Returns
 
@@ -43,6 +43,6 @@ Error.constructor
 
 ## Properties
 
-### cause
+### errorCause
 
-• `Optional` **cause**: `Error`
+• `Optional` **errorCause**: `Error`

--- a/docs/classes/errors.WorkflowError.md
+++ b/docs/classes/errors.WorkflowError.md
@@ -18,20 +18,20 @@
 
 ### Properties
 
-- [originalError](errors.WorkflowError.md#originalerror)
+- [cause](errors.WorkflowError.md#cause)
 
 ## Constructors
 
 ### constructor
 
-• **new WorkflowError**(`message`, `originalError?`): [`WorkflowError`](errors.WorkflowError.md)
+• **new WorkflowError**(`message`, `cause?`): [`WorkflowError`](errors.WorkflowError.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message` | `string` |
-| `originalError?` | `Error` |
+| `cause?` | `Error` |
 
 #### Returns
 
@@ -43,6 +43,6 @@ Error.constructor
 
 ## Properties
 
-### originalError
+### cause
 
-• `Optional` **originalError**: `Error`
+• `Optional` **cause**: `Error`

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cross-fetch": "^4.0.0",
         "debug": "^4.3.4",
         "ethers": "^6.11.0",
-        "iexec": "^8.5.0",
+        "iexec": "^8.9.1",
         "jsonpath": "^1.1.1",
         "kubo-rpc-client": "^3.0.2",
         "yup": "^1.3.3"
@@ -41,7 +41,7 @@
         "typedoc-plugin-markdown": "^3.17.1",
         "typedoc-plugin-missing-exports": "^2.2.0",
         "typedoc-plugin-rename-defaults": "^0.7.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5.5.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5177,9 +5177,9 @@
       ]
     },
     "node_modules/iexec": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.5.2.tgz",
-      "integrity": "sha512-T+QkRZTNW0eWiQ/qMeCEMazvtccNZ6qBp/pwy6JOEEDwIM4+twgRLgr/9TDTiVf//xlykEp6bUBxq+dtCcoYCg==",
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.9.1.tgz",
+      "integrity": "sha512-WK+OrCF5BVAKtAcPwuhkCz8aQ8UDx/WmEdu7yHeZKUfY/M7Pipit53uiv6m74w9JAJULVspV5sHSBk8WZDa9zg==",
       "dependencies": {
         "@ensdomains/ens-contracts": "^0.0.22",
         "@iexec/erlc": "^1.0.0",
@@ -9213,9 +9213,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
         "ts-node": "^10.9.2",
-        "typedoc": "^0.25.8",
+        "typedoc": "^0.26.2",
         "typedoc-plugin-markdown": "^3.17.1",
         "typedoc-plugin-missing-exports": "^2.2.0",
         "typedoc-plugin-rename-defaults": "^0.7.0",
@@ -1901,6 +1901,12 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@shikijs/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-EmUful2MQtY8KgCF1OkBtOuMcvaZEvmdubhW0UHCGXi21O9dRLeADVCj+k6ZS+de7Mz9d2qixOXJ+GLhcK3pXg==",
+      "dev": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2622,12 +2628,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -3693,6 +3693,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/err-code": {
@@ -7080,6 +7092,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7182,17 +7203,28 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "engines": {
-        "node": ">= 12"
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -8067,6 +8099,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
@@ -8530,15 +8571,12 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.9.1.tgz",
+      "integrity": "sha512-8PDkgb5ja3nfujTjvC4VytL6wGOGCtFAClUb2r3QROevYXxcq+/shVJK5s6gy0HZnjaJgFxd6BpPqpRfqne5rA==",
       "dev": true,
       "dependencies": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
+        "@shikijs/core": "1.9.1"
       }
     },
     "node_modules/side-channel": {
@@ -9147,24 +9185,25 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.9.tgz",
-      "integrity": "sha512-jVoGmfNw848iW0L313+jqHbsknepwDV6F9nzk1H30oWhKXkw65uaENgR6QtTw9a5KqRWEb6nwNd54KxffBJyWw==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.2.tgz",
+      "integrity": "sha512-q/t+M+PZqhN9gPWLBZ3CCvP+KT8O1tyYkSzEYbcQ6mo89avdIrMlBEl3vfo5BgSzwC6Lbmq0W64E8RkY+eVsLA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.3.0",
-        "minimatch": "^9.0.3",
-        "shiki": "^0.14.7"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.4",
+        "shiki": "^1.9.0",
+        "yaml": "^2.4.5"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {
@@ -9212,6 +9251,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
@@ -9224,6 +9278,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -9406,18 +9466,6 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -9579,6 +9627,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
         "prettier": "^3.2.5",
         "ts-node": "^10.9.2",
         "typedoc": "^0.26.2",
-        "typedoc-plugin-markdown": "^3.17.1",
-        "typedoc-plugin-missing-exports": "^2.2.0",
-        "typedoc-plugin-rename-defaults": "^0.7.0",
+        "typedoc-plugin-markdown": "^4.1.0",
+        "typedoc-plugin-missing-exports": "^3.0.0",
+        "typedoc-plugin-rename-defaults": "^0.7.1",
         "typescript": "^5.5.2"
       }
     },
@@ -5041,27 +5041,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -7387,12 +7366,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -9207,36 +9180,36 @@
       }
     },
     "node_modules/typedoc-plugin-markdown": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
-      "integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.1.0.tgz",
+      "integrity": "sha512-sUiEJVaa6+MOFShRy14j1OP/VXC5OLyHNecJ2nKeGuBy2M3YiMatSLoIiddFAqVptSuILJTZiJzCBIY6yzAVyg==",
       "dev": true,
-      "dependencies": {
-        "handlebars": "^4.7.7"
+      "engines": {
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "typedoc": ">=0.24.0"
+        "typedoc": "0.26.x"
       }
     },
     "node_modules/typedoc-plugin-missing-exports": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.2.0.tgz",
-      "integrity": "sha512-2+XR1IcyQ5UwXZVJe9NE6HrLmNufT9i5OwoIuuj79VxuA3eYq+Y6itS9rnNV1D7UeQnUSH8kISYD73gHE5zw+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.0.0.tgz",
+      "integrity": "sha512-R7D8fYrK34mBFZSlF1EqJxfqiUSlQSmyrCiQgTQD52nNm6+kUtqwiaqaNkuJ2rA2wBgWFecUA8JzHT7x2r7ePg==",
       "dev": true,
       "peerDependencies": {
-        "typedoc": "0.24.x || 0.25.x"
+        "typedoc": "0.26.x"
       }
     },
     "node_modules/typedoc-plugin-rename-defaults": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.0.tgz",
-      "integrity": "sha512-NudSQ1o/XLHNF9c4y7LzIZxfE9ltz09yCDklBPJpP5VMRvuBpYGIbQ0ZgmPz+EIV8vPx9Z/OyKwzp4HT2vDtfg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.1.tgz",
+      "integrity": "sha512-hgg4mAy5IumgUmPOnVVGmGywjTGtUCmRJ2jRbseqtXdlUuYKj652ODL9joUWFt5uvNu4Dr/pNILc/qsKGHJw+w==",
       "dev": true,
       "dependencies": {
         "camelcase": "^8.0.0"
       },
       "peerDependencies": {
-        "typedoc": "0.22.x || 0.23.x || 0.24.x || 0.25.x"
+        "typedoc": ">=0.22.x <0.27.x"
       }
     },
     "node_modules/typedoc-plugin-rename-defaults/node_modules/camelcase": {
@@ -9284,19 +9257,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
-    },
-    "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
@@ -9554,12 +9514,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
-    "typedoc": "^0.25.8",
+    "typedoc": "^0.26.2",
     "typedoc-plugin-markdown": "^3.17.1",
     "typedoc-plugin-missing-exports": "^2.2.0",
     "typedoc-plugin-rename-defaults": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.26.2",
-    "typedoc-plugin-markdown": "^3.17.1",
-    "typedoc-plugin-missing-exports": "^2.2.0",
-    "typedoc-plugin-rename-defaults": "^0.7.0",
+    "typedoc-plugin-markdown": "^4.1.0",
+    "typedoc-plugin-missing-exports": "^3.0.0",
+    "typedoc-plugin-rename-defaults": "^0.7.1",
     "typescript": "^5.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cross-fetch": "^4.0.0",
     "debug": "^4.3.4",
     "ethers": "^6.11.0",
-    "iexec": "^8.5.0",
+    "iexec": "^8.9.1",
     "jsonpath": "^1.1.1",
     "kubo-rpc-client": "^3.0.2",
     "yup": "^1.3.3"
@@ -74,6 +74,6 @@
     "typedoc-plugin-markdown": "^3.17.1",
     "typedoc-plugin-missing-exports": "^2.2.0",
     "typedoc-plugin-rename-defaults": "^0.7.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.2"
   }
 }

--- a/src/oracleFactory/createOracle.ts
+++ b/src/oracleFactory/createOracle.ts
@@ -138,7 +138,7 @@ const createApiKeyDataset = ({
             })
             .catch((e: Error) => {
               throw new WorkflowError({
-                message: "Failed to create API key datasetorder's",
+                message: 'Failed to create API key dataset order',
                 errorCause: e,
               });
             });

--- a/src/oracleFactory/createOracle.ts
+++ b/src/oracleFactory/createOracle.ts
@@ -69,7 +69,7 @@ const createApiKeyDataset = ({
             .catch((e: Error) => {
               throw new WorkflowError({
                 message: 'Failed to encrypt API key',
-                cause: e,
+                errorCause: e,
               });
             });
           if (abort) return;
@@ -78,7 +78,7 @@ const createApiKeyDataset = ({
             .catch((e: Error) => {
               throw new WorkflowError({
                 message: 'Failed to compute encrypted API key checksum',
-                cause: e,
+                errorCause: e,
               });
             });
           if (abort) return;
@@ -93,7 +93,7 @@ const createApiKeyDataset = ({
             .catch((e) => {
               throw new WorkflowError({
                 message: 'Failed to upload encrypted API key',
-                cause: e,
+                errorCause: e,
               });
             });
           if (abort) return;
@@ -107,19 +107,12 @@ const createApiKeyDataset = ({
           safeObserver.next({
             message: 'DATASET_DEPLOYMENT_SIGN_TX_REQUEST',
           });
-          const { address, txHash } = await iexec.dataset
-            .deployDataset({
-              owner: await iexec.wallet.getAddress(),
-              name: 'api-key',
-              multiaddr,
-              checksum,
-            })
-            .catch((e: Error) => {
-              throw new WorkflowError({
-                message: 'Failed to deploy API key dataset',
-                cause: e,
-              });
-            });
+          const { address, txHash } = await iexec.dataset.deployDataset({
+            owner: await iexec.wallet.getAddress(),
+            name: 'api-key',
+            multiaddr,
+            checksum,
+          });
           if (abort) return;
           safeObserver.next({
             message: 'DATASET_DEPLOYMENT_SUCCESS',
@@ -130,32 +123,18 @@ const createApiKeyDataset = ({
           safeObserver.next({
             message: 'PUSH_SECRET_TO_SMS_SIGN_REQUEST',
           });
-          await iexec.dataset
-            .pushDatasetSecret(address, key)
-            .catch((e: Error) => {
-              throw new WorkflowError({
-                message: "Failed to push API key dataset's encryption key",
-                cause: e,
-              });
-            });
+          await iexec.dataset.pushDatasetSecret(address, key);
           if (abort) return;
           safeObserver.next({
             message: 'PUSH_SECRET_TO_SMS_SUCCESS',
           });
 
-          const orderToSign = await iexec.order
-            .createDatasetorder({
-              dataset: address,
-              tag: ['tee', 'scone'],
-              apprestrict: ORACLE_APP_ADDRESS,
-              volume: Number.MAX_SAFE_INTEGER - 1,
-            })
-            .catch((e: Error) => {
-              throw new WorkflowError({
-                message: "Failed to create API key datasetorder's",
-                cause: e,
-              });
-            });
+          const orderToSign = await iexec.order.createDatasetorder({
+            dataset: address,
+            tag: ['tee', 'scone'],
+            apprestrict: ORACLE_APP_ADDRESS,
+            volume: Number.MAX_SAFE_INTEGER - 1,
+          });
           if (abort) return;
           safeObserver.next({
             message: 'DATASET_ORDER_SIGNATURE_SIGN_REQUEST',
@@ -166,7 +145,7 @@ const createApiKeyDataset = ({
             .catch((e: Error) => {
               throw new WorkflowError({
                 message: "Failed to sign API key datasetorder's",
-                cause: e,
+                errorCause: e,
               });
             });
           if (abort) return;
@@ -179,14 +158,7 @@ const createApiKeyDataset = ({
             message: 'DATASET_ORDER_PUBLISH_SIGN_REQUEST',
             order,
           });
-          const orderHash = await iexec.order
-            .publishDatasetorder(order)
-            .catch((e: Error) => {
-              throw new WorkflowError({
-                message: "Failed to publish API key datasetorder's",
-                cause: e,
-              });
-            });
+          const orderHash = await iexec.order.publishDatasetorder(order);
           if (abort) return;
           safeObserver.next({
             message: 'DATASET_ORDER_PUBLISH_SUCCESS',
@@ -202,8 +174,9 @@ const createApiKeyDataset = ({
           } else {
             safeObserver.error(
               new WorkflowError({
-                message: 'API key dataset creation unexpected error',
-                cause: e,
+                message:
+                  'Failed to create dataset containing encrypted API key',
+                errorCause: e,
               })
             );
           }
@@ -321,7 +294,7 @@ const createOracle = ({
             .catch((e) => {
               throw new WorkflowError({
                 message: 'Failed to upload paramSet',
-                cause: e,
+                errorCause: e,
               });
             });
           if (abort) return;
@@ -341,8 +314,8 @@ const createOracle = ({
           } else {
             safeObserver.error(
               new WorkflowError({
-                message: 'Create oracle unexpected error',
-                cause: e,
+                message: 'Failed to create oracle',
+                errorCause: e,
               })
             );
           }

--- a/src/oracleFactory/createOracle.ts
+++ b/src/oracleFactory/createOracle.ts
@@ -129,12 +129,19 @@ const createApiKeyDataset = ({
             message: 'PUSH_SECRET_TO_SMS_SUCCESS',
           });
 
-          const orderToSign = await iexec.order.createDatasetorder({
-            dataset: address,
-            tag: ['tee', 'scone'],
-            apprestrict: ORACLE_APP_ADDRESS,
-            volume: Number.MAX_SAFE_INTEGER - 1,
-          });
+          const orderToSign = await iexec.order
+            .createDatasetorder({
+              dataset: address,
+              tag: ['tee', 'scone'],
+              apprestrict: ORACLE_APP_ADDRESS,
+              volume: Number.MAX_SAFE_INTEGER - 1,
+            })
+            .catch((e: Error) => {
+              throw new WorkflowError({
+                message: "Failed to create API key datasetorder's",
+                errorCause: e,
+              });
+            });
           if (abort) return;
           safeObserver.next({
             message: 'DATASET_ORDER_SIGNATURE_SIGN_REQUEST',

--- a/src/oracleFactory/readOracle.ts
+++ b/src/oracleFactory/readOracle.ts
@@ -66,7 +66,7 @@ const readOracle = async ({
       } else {
         throw new WorkflowError({
           message: 'Failed to load paramSet',
-          cause: e,
+          errorCause: e,
         });
       }
     });

--- a/src/oracleFactory/readOracle.ts
+++ b/src/oracleFactory/readOracle.ts
@@ -64,7 +64,10 @@ const readOracle = async ({
       if (e instanceof ValidationError) {
         throw e;
       } else {
-        throw new WorkflowError('Failed to load paramSet', e);
+        throw new WorkflowError({
+          message: 'Failed to load paramSet',
+          cause: e,
+        });
       }
     });
     readDataType = paramSet.dataType;

--- a/src/oracleFactory/updateOracle.ts
+++ b/src/oracleFactory/updateOracle.ts
@@ -296,22 +296,15 @@ const updateOracle = ({
           workerpoolorder,
           requestorder,
         });
-        const { dealid, txHash } = await iexec.order
-          .matchOrders(
-            {
-              apporder,
-              datasetorder,
-              workerpoolorder,
-              requestorder,
-            },
-            { preflightCheck: false }
-          )
-          .catch((e) => {
-            throw new WorkflowError({
-              message: 'Failed to match orders',
-              errorCause: e,
-            });
-          });
+        const { dealid, txHash } = await iexec.order.matchOrders(
+          {
+            apporder,
+            datasetorder,
+            workerpoolorder,
+            requestorder,
+          },
+          { preflightCheck: false }
+        );
         if (abort) return;
         safeObserver.next({
           message: 'MATCH_ORDERS_SUCCESS',

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,17 +1,23 @@
+import { ApiCallError } from 'iexec/errors';
 import { ValidationError } from 'yup';
 
-class WorkflowError extends Error {
-  originalError?: Error;
-
-  constructor(message: string, originalError?: Error) {
-    super(message);
+export class WorkflowError extends Error {
+  constructor(message: string, cause: Error) {
+    super(message, { cause: cause });
     this.name = this.constructor.name;
-    if (originalError) {
-      this.originalError = originalError;
-    }
   }
 }
 
-class NoValueError extends Error {}
+export function handleProtocolError(error: Error): boolean {
+  if (error instanceof ApiCallError) {
+    throw new WorkflowError(
+      "A service in the iExec protocol appears to be unavailable. You can retry later or contact iExec's technical support for help.",
+      error
+    );
+  }
+  return false;
+}
 
-export { ValidationError, WorkflowError, NoValueError };
+export class NoValueError extends Error {}
+
+export { ValidationError };

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -9,14 +9,14 @@ export class WorkflowError extends Error {
 
   constructor({
     message,
-    cause,
+    errorCause,
     isProtocolError = false,
   }: {
     message: string;
-    cause: Error;
+    errorCause: Error;
     isProtocolError?: boolean;
   }) {
-    super(message, { cause: cause });
+    super(message, { cause: errorCause });
     this.name = this.constructor.name;
     this.isProtocolError = isProtocolError;
   }
@@ -31,7 +31,7 @@ export function handleIfProtocolError(
       new WorkflowError({
         message:
           "A service in the iExec protocol appears to be unavailable. You can retry later or contact iExec's technical support for help.",
-        cause: error,
+        errorCause: error,
         isProtocolError: true,
       })
     );

--- a/tests/e2e/IExecOracleFactory/createOracle.e2e.test.ts
+++ b/tests/e2e/IExecOracleFactory/createOracle.e2e.test.ts
@@ -1,6 +1,8 @@
 import { Wallet } from 'ethers';
 import { utils } from 'iexec';
+import { SmsCallError, MarketCallError } from 'iexec/errors';
 import { IExecOracleFactory } from '../../../src/index.js';
+import { WorkflowError } from '../../../src/utils/errors.js';
 
 test('create oracle - without dataset', async () => {
   const ethProvider = utils.getSignerFromPrivateKey(
@@ -132,3 +134,102 @@ test('cancel - with apiKey', async () => {
   expect(messages.length).toBe(1);
   expect(messages[0].message).toStrictEqual('ENCRYPTION_KEY_CREATED');
 }, 10000);
+
+test('create oracle - protocol error by unavailable sms url', async () => {
+  const ethProvider = utils.getSignerFromPrivateKey(
+    'bellecour',
+    Wallet.createRandom().privateKey
+  );
+  const factory = new IExecOracleFactory(ethProvider, {
+    iexecOptions: {
+      // iexecGatewayURL: 'https://invalidurl',
+      smsURL: 'https://unavailable.sms.url',
+    },
+  });
+  let error: WorkflowError | undefined;
+  try {
+    await new Promise((resolve: any, reject) => {
+      factory
+        .createOracle({
+          url: 'https://foo.io',
+          method: 'GET',
+          headers: {
+            authorization: '%API_KEY%',
+          },
+          dataType: 'string',
+          JSONPath: '$.data',
+          apiKey: 'foo',
+        })
+        .subscribe({
+          complete: resolve,
+          error: (e) => {
+            reject(e);
+          },
+          next: () => {},
+        });
+    });
+  } catch (e) {
+    error = e as WorkflowError;
+  }
+
+  expect(error).toBeInstanceOf(WorkflowError);
+  expect(error.message).toBe(
+    "A service in the iExec protocol appears to be unavailable. You can retry later or contact iExec's technical support for help."
+  );
+  expect(error.cause).toStrictEqual(
+    new SmsCallError(
+      'Connection to https://unavailable.sms.url failed with a network error',
+      Error('original error trace')
+    )
+  );
+  expect(error.isProtocolError).toBe(true);
+}, 30000);
+
+test('create oracle - protocol error unavailable market url', async () => {
+  const ethProvider = utils.getSignerFromPrivateKey(
+    'bellecour',
+    Wallet.createRandom().privateKey
+  );
+  const factory = new IExecOracleFactory(ethProvider, {
+    iexecOptions: {
+      iexecGatewayURL: 'https://unavailable.market.url',
+    },
+  });
+  let error: WorkflowError | undefined;
+  try {
+    await new Promise((resolve: any, reject) => {
+      factory
+        .createOracle({
+          url: 'https://foo.io',
+          method: 'GET',
+          headers: {
+            authorization: '%API_KEY%',
+          },
+          dataType: 'string',
+          JSONPath: '$.data',
+          apiKey: 'foo',
+        })
+        .subscribe({
+          complete: resolve,
+          error: (e) => {
+            reject(e);
+          },
+          next: () => {},
+        });
+    });
+  } catch (e) {
+    error = e as WorkflowError;
+  }
+
+  expect(error).toBeInstanceOf(WorkflowError);
+  expect(error.message).toBe(
+    "A service in the iExec protocol appears to be unavailable. You can retry later or contact iExec's technical support for help."
+  );
+  expect(error.cause).toStrictEqual(
+    new MarketCallError(
+      'Connection to https://unavailable.market.url failed with a network error',
+      Error('original error trace')
+    )
+  );
+  expect(error.isProtocolError).toBe(true);
+}, 30000);

--- a/tests/e2e/IExecOracleFactory/readOracle.e2e.test.ts
+++ b/tests/e2e/IExecOracleFactory/readOracle.e2e.test.ts
@@ -1,16 +1,9 @@
-import { Wallet } from 'ethers';
-import { utils } from 'iexec';
-import { IExecOracleFactory } from '../../../src/index.js';
+import { IExecOracleReader } from '../../../src/index.js';
 
 describe('readOracle', () => {
   test('standard - from paramSet dataType: "boolean"', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle({
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle({
       JSONPath: '$.ok',
       body: '',
       dataType: 'boolean',
@@ -25,13 +18,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from paramSet dataType: "number"', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle({
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle({
       JSONPath: "$['ethereum']['usd']",
       body: '',
       dataType: 'number',
@@ -46,13 +34,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from paramSet dataType: "string"', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle({
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle({
       JSONPath: '$.version',
       body: '',
       dataType: 'string',
@@ -67,13 +50,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from CID', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle(
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle(
       'Qmb1JLTVp4zfRMPaori9htzzM9D3B1tG8pGbZYTRC1favA'
     );
     const { value, date } = res;
@@ -82,13 +60,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from oracleId (default dataType)', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle(
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle(
       '0xf0f370ad33d1e3e8e2d8df7197c40f62b5bc403553b103858359687491234491'
     );
     const { value, date } = res;
@@ -97,13 +70,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from oracleId (dataType number)', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle(
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle(
       '0x31172fe38a7be8a62fa4882d3a5b5cf7da13fa6ad5b144a0c2f35b559bbba14f',
       { dataType: 'number' }
     );
@@ -113,13 +81,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from oracleId (dataType string)', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle(
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle(
       '0x9fc5c194d4898197e535060b54256435fda773ae59c93cf88be84bce1ca4ce3e',
       { dataType: 'string' }
     );
@@ -129,13 +92,8 @@ describe('readOracle', () => {
   });
 
   test('standard - from oracleId (dataType boolean)', async () => {
-    const ethProvider = utils.getSignerFromPrivateKey(
-      'bellecour',
-      Wallet.createRandom().privateKey
-    );
-    const factoryWithoutOption = new IExecOracleFactory(ethProvider);
-
-    const res = await factoryWithoutOption.readOracle(
+    const oracleReader = new IExecOracleReader(134);
+    const res = await oracleReader.readOracle(
       '0xccf7d910abf22fbeeef17f861b5cf9abb9543e48ee502285f7df53c63296ce21',
       { dataType: 'boolean' }
     );

--- a/tests/unit/IExecOracleFactory/createOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/createOracle.test.ts
@@ -553,7 +553,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to create oracle: fake error');
+    expect(errors[0].message).toBe('Create oracle unexpected error');
     expect(errors[0].cause).toBeInstanceOf(TypeError);
   }, 10000);
 
@@ -1000,9 +1000,7 @@ describe('createOracle', () => {
     expect(messages.length).toBe(0);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe(
-      'Failed to create oracle: something bad happened'
-    );
+    expect(errors[0].message).toBe('API key dataset creation unexpected error');
     expect(errors[0].cause).toStrictEqual(Error('something bad happened'));
   }, 10000);
 });

--- a/tests/unit/IExecOracleFactory/createOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/createOracle.test.ts
@@ -874,9 +874,7 @@ describe('createOracle', () => {
     expect(messages.length).toBe(7);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe(
-      'Failed to create dataset containing encrypted API key'
-    );
+    expect(errors[0].message).toBe('Failed to create API key dataset order');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.createDatasetorder failed')
     );

--- a/tests/unit/IExecOracleFactory/createOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/createOracle.test.ts
@@ -553,7 +553,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Create oracle unexpected error');
+    expect(errors[0].message).toBe('Failed to create oracle');
     expect(errors[0].cause).toBeInstanceOf(TypeError);
   }, 10000);
 
@@ -740,7 +740,9 @@ describe('createOracle', () => {
     expect(messages.length).toBe(4);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to deploy API key dataset');
+    expect(errors[0].message).toBe(
+      'Failed to create dataset containing encrypted API key'
+    );
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.dataset.deployDataset failed')
     );
@@ -803,7 +805,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe(
-      "Failed to push API key dataset's encryption key"
+      'Failed to create dataset containing encrypted API key'
     );
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.dataset.pushDatasetSecret failed')
@@ -872,7 +874,9 @@ describe('createOracle', () => {
     expect(messages.length).toBe(7);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe("Failed to create API key datasetorder's");
+    expect(errors[0].message).toBe(
+      'Failed to create dataset containing encrypted API key'
+    );
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.createDatasetorder failed')
     );
@@ -1000,7 +1004,9 @@ describe('createOracle', () => {
     expect(messages.length).toBe(0);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('API key dataset creation unexpected error');
+    expect(errors[0].message).toBe(
+      'Failed to create dataset containing encrypted API key'
+    );
     expect(errors[0].cause).toStrictEqual(Error('something bad happened'));
   }, 10000);
 });

--- a/tests/unit/IExecOracleFactory/createOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/createOracle.test.ts
@@ -516,7 +516,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to upload paramSet');
-    expect(errors[0].originalError).toStrictEqual(Error('ipfs.add failed'));
+    expect(errors[0].cause).toStrictEqual(Error('ipfs.add failed'));
   }, 10000);
 
   test('error - unexpected error', async () => {
@@ -553,8 +553,8 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Create oracle unexpected error');
-    expect(errors[0].originalError).toBeInstanceOf(TypeError);
+    expect(errors[0].message).toBe('Failed to create oracle: fake error');
+    expect(errors[0].cause).toBeInstanceOf(TypeError);
   }, 10000);
 
   test('error - with apiKey failed to encrypt apiKey', async () => {
@@ -599,7 +599,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to encrypt API key');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.dataset.encrypt failed')
     );
   }, 10000);
@@ -651,7 +651,7 @@ describe('createOracle', () => {
     expect(errors[0].message).toBe(
       'Failed to compute encrypted API key checksum'
     );
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.dataset.computeEncryptedFileChecksum failed')
     );
   }, 10000);
@@ -692,7 +692,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to upload encrypted API key');
-    expect(errors[0].originalError).toStrictEqual(Error('ipfs.add failed'));
+    expect(errors[0].cause).toStrictEqual(Error('ipfs.add failed'));
   }, 10000);
 
   test('error - with apiKey failed to deploy dataset', async () => {
@@ -741,7 +741,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to deploy API key dataset');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.dataset.deployDataset failed')
     );
   }, 10000);
@@ -805,7 +805,7 @@ describe('createOracle', () => {
     expect(errors[0].message).toBe(
       "Failed to push API key dataset's encryption key"
     );
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.dataset.pushDatasetSecret failed')
     );
   }, 10000);
@@ -873,7 +873,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe("Failed to create API key datasetorder's");
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.createDatasetorder failed')
     );
   }, 10000);
@@ -955,7 +955,7 @@ describe('createOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe("Failed to sign API key datasetorder's");
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.signDatasetorder failed')
     );
   }, 10000);
@@ -1000,9 +1000,9 @@ describe('createOracle', () => {
     expect(messages.length).toBe(0);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('API key dataset creation unexpected error');
-    expect(errors[0].originalError).toStrictEqual(
-      Error('something bad happened')
+    expect(errors[0].message).toBe(
+      'Failed to create oracle: something bad happened'
     );
+    expect(errors[0].cause).toStrictEqual(Error('something bad happened'));
   }, 10000);
 });

--- a/tests/unit/IExecOracleFactory/readOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/readOracle.test.ts
@@ -271,10 +271,10 @@ describe('readOracle', () => {
         paramSetOrCidOrOracleId: paramsetCID,
       })
     ).rejects.toThrow(
-      new WorkflowError(
-        'Failed to load paramSet',
-        Error(`Failed to load paramSetSet from CID ${paramsetCID}`)
-      )
+      new WorkflowError({
+        message: 'Failed to load paramSet',
+        cause: Error(`Failed to load paramSetSet from CID ${paramsetCID}`),
+      })
     );
   });
 

--- a/tests/unit/IExecOracleFactory/readOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/readOracle.test.ts
@@ -264,14 +264,17 @@ describe('readOracle', () => {
     mockGet.mockRejectedValueOnce(Error('ipfs.get failed'));
     mockIsCid.mockResolvedValueOnce(true);
     const provider = getDefaultProvider('https://bellecour.iex.ec', {});
+    const paramsetCID = 'QmTJ41EuPEwiPTGrYVPbXgMGvmgzsRYWWMmw6krVDN94nh';
     await expect(
       readOracle({
         ethersProvider: provider,
-        paramSetOrCidOrOracleId:
-          'QmTJ41EuPEwiPTGrYVPbXgMGvmgzsRYWWMmw6krVDN94nh',
+        paramSetOrCidOrOracleId: paramsetCID,
       })
     ).rejects.toThrow(
-      new WorkflowError('Failed to load paramSet', Error('ipfs.get failed'))
+      new WorkflowError(
+        'Failed to load paramSet',
+        Error(`Failed to load paramSetSet from CID ${paramsetCID}`)
+      )
     );
   });
 

--- a/tests/unit/IExecOracleFactory/readOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/readOracle.test.ts
@@ -273,7 +273,7 @@ describe('readOracle', () => {
     ).rejects.toThrow(
       new WorkflowError({
         message: 'Failed to load paramSet',
-        cause: Error(`Failed to load paramSetSet from CID ${paramsetCID}`),
+        errorCause: Error(`Failed to load paramSetSet from CID ${paramsetCID}`),
       })
     );
   });

--- a/tests/unit/IExecOracleFactory/updateOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/updateOracle.test.ts
@@ -789,7 +789,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(4);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to fetch app order');
+    expect(errors[0].message).toBe('Failed to update oracle');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchAppOrderbook failed')
     );
@@ -889,7 +889,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(6);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to fetch dataset order');
+    expect(errors[0].message).toBe('Failed to update oracle');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchDatasetOrderbook fail')
     );
@@ -997,7 +997,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(8);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to fetch workerpool order');
+    expect(errors[0].message).toBe('Failed to update oracle');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchWorkerpoolOrderbook fail')
     );
@@ -1444,7 +1444,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(2);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Update oracle unexpected error');
+    expect(errors[0].message).toBe('Failed to update oracle');
     expect(errors[0].cause).toBeInstanceOf(TypeError);
   }, 10000);
 });

--- a/tests/unit/IExecOracleFactory/updateOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/updateOracle.test.ts
@@ -1248,7 +1248,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(12);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to match orders');
+    expect(errors[0].message).toBe('Failed to update oracle');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.matchOrders failed')
     );

--- a/tests/unit/IExecOracleFactory/updateOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/updateOracle.test.ts
@@ -789,7 +789,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(4);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to fetch apporder');
+    expect(errors[0].message).toBe('Failed to fetch app order');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchAppOrderbook failed')
     );
@@ -837,8 +837,8 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(4);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('No apporder published');
-    expect(errors[0].cause).toBeUndefined();
+    expect(errors[0].message).toBe('Failed to update oracle');
+    expect(errors[0].cause).toStrictEqual(Error('No app order published'));
   }, 10000);
 
   test('error - fail to fetch datasetorder', async () => {
@@ -889,7 +889,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(6);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to fetch datasetorder');
+    expect(errors[0].message).toBe('Failed to fetch dataset order');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchDatasetOrderbook fail')
     );
@@ -941,11 +941,11 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(6);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('No datasetorder published');
-    expect(errors[0].cause).toBeUndefined();
+    expect(errors[0].message).toBe('Failed to update oracle');
+    expect(errors[0].cause).toStrictEqual(Error('No dataset order published'));
   }, 10000);
 
-  test('error - fail to fetch workerppolorder', async () => {
+  test('error - fail to fetch workerpool order', async () => {
     mockAdd.mockResolvedValueOnce(
       'QmTJ41EuPEwiPTGrYVPbXgMGvmgzsRYWWMmw6krVDN94nh'
     ) as any;
@@ -997,7 +997,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(8);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to fetch workerpoolorder');
+    expect(errors[0].message).toBe('Failed to fetch workerpool order');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchWorkerpoolOrderbook fail')
     );
@@ -1053,8 +1053,10 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(8);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('No workerpoolorder published');
-    expect(errors[0].cause).toBeUndefined();
+    expect(errors[0].message).toBe('Failed to update oracle');
+    expect(errors[0].cause).toStrictEqual(
+      Error('No workerpool order published')
+    );
   }, 10000);
 
   test('error - fail to create requestorder', async () => {
@@ -1113,7 +1115,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(9);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to create requestorder');
+    expect(errors[0].message).toBe('Failed to create request order');
     expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.createRequestorder failed')
     );
@@ -1442,7 +1444,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(2);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Failed to update oracle: fake error');
+    expect(errors[0].message).toBe('Update oracle unexpected error');
     expect(errors[0].cause).toBeInstanceOf(TypeError);
   }, 10000);
 });

--- a/tests/unit/IExecOracleFactory/updateOracle.test.ts
+++ b/tests/unit/IExecOracleFactory/updateOracle.test.ts
@@ -627,7 +627,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to load paramSet');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error(
         'Failed to load paramSetSet from CID QmTJ41EuPEwiPTGrYVPbXgMGvmgzsRYWWMmw6krVDN94nh'
       )
@@ -666,7 +666,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     // expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to load paramSet');
-    // expect(errors[0].originalError).toStrictEqual(
+    // expect(errors[0].cause).toStrictEqual(
     //   Error(
     //     'Content associated to CID QmTJ41EuPEwiPTGrYVPbXgMGvmgzsRYWWMmw6krVDN94nh is not a valid paramSet',
     //   ),
@@ -742,7 +742,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to upload paramSet');
-    expect(errors[0].originalError).toStrictEqual(Error('ipfs.add failed'));
+    expect(errors[0].cause).toStrictEqual(Error('ipfs.add failed'));
   }, 10000);
 
   test('error - fail to fetch apporder', async () => {
@@ -790,7 +790,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to fetch apporder');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchAppOrderbook failed')
     );
   }, 10000);
@@ -838,7 +838,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('No apporder published');
-    expect(errors[0].originalError).toBeUndefined();
+    expect(errors[0].cause).toBeUndefined();
   }, 10000);
 
   test('error - fail to fetch datasetorder', async () => {
@@ -890,7 +890,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to fetch datasetorder');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchDatasetOrderbook fail')
     );
   }, 10000);
@@ -942,7 +942,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('No datasetorder published');
-    expect(errors[0].originalError).toBeUndefined();
+    expect(errors[0].cause).toBeUndefined();
   }, 10000);
 
   test('error - fail to fetch workerppolorder', async () => {
@@ -998,7 +998,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to fetch workerpoolorder');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.orderbook.fetchWorkerpoolOrderbook fail')
     );
   }, 10000);
@@ -1054,7 +1054,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('No workerpoolorder published');
-    expect(errors[0].originalError).toBeUndefined();
+    expect(errors[0].cause).toBeUndefined();
   }, 10000);
 
   test('error - fail to create requestorder', async () => {
@@ -1114,7 +1114,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to create requestorder');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.createRequestorder failed')
     );
   }, 10000);
@@ -1179,7 +1179,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to sign requestorder');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.signRequestorder failed')
     );
   }, 10000);
@@ -1247,7 +1247,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to match orders');
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('iexec.order.matchOrders failed')
     );
   }, 10000);
@@ -1322,9 +1322,7 @@ describe('updateOracle', () => {
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
     expect(errors[0].message).toBe('Failed to monitor oracle update task');
-    expect(errors[0].originalError).toStrictEqual(
-      Error('iexec.task.obsTask error')
-    );
+    expect(errors[0].cause).toStrictEqual(Error('iexec.task.obsTask error'));
   }, 10000);
 
   test('error - update task timedout', async () => {
@@ -1400,7 +1398,7 @@ describe('updateOracle', () => {
     expect(errors[0].message).toBe(
       'Oracle update task timed out, update failed'
     );
-    expect(errors[0].originalError).toStrictEqual(
+    expect(errors[0].cause).toStrictEqual(
       Error('Task taskid from deal dealid timed out')
     );
   }, 10000);
@@ -1444,7 +1442,7 @@ describe('updateOracle', () => {
     expect(messages.length).toBe(2);
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(WorkflowError);
-    expect(errors[0].message).toBe('Update oracle unexpected error');
-    expect(errors[0].originalError).toBeInstanceOf(TypeError);
+    expect(errors[0].message).toBe('Failed to update oracle: fake error');
+    expect(errors[0].cause).toBeInstanceOf(TypeError);
   }, 10000);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "nodenext",
-    "target": "es2017",
+    "target": "ES2023",
     "declaration": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "nodenext",
-    "target": "ES2023",
+    "module": "node16",
+    "target": "ES2022",
     "declaration": true,
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
Added the following errors during iExec protocol services unavailability

create oracle 
- throws SmsCallError as cause during encrypted dataset key push
- throws MarketCallError as cause during dataset order publication

update oracle
- throws MarketCallError as cause during fetching app/dataset/workerpool orders
- throws WorkerpoolCallError as cause during task watch execution

no modifications were made on read oracle since it does not pass by the iexec sdk to contact the ipfs gateway